### PR TITLE
[WFLY-11849] adding information about timeout of the bridged transactions

### DIFF
--- a/product/en-US/txbridge_guide/using_the_transaction_bridge.xml
+++ b/product/en-US/txbridge_guide/using_the_transaction_bridge.xml
@@ -92,6 +92,12 @@
             with the handlers registered only on the former. This limitation may be addressed in future
             versions.
         </para>
+        <para>
+            If WS-AT transaction context contains transaction timeout then the bridged JTA
+            transaction is created with this timeout. If the context does not provide
+            the information then the bridged JTA transaction is created
+            with the default timeout defined by the container.
+        </para>
     </section>
     <section>
         <title>Outbound Bridging</title>

--- a/project/en-US/rts/integrating_with_other_transaction_models.xml
+++ b/project/en-US/rts/integrating_with_other_transaction_models.xml
@@ -55,6 +55,12 @@ public class JAXRSResource {
     }
 }
             </programlisting>
+
+            <para>
+                REST-AT transaction context does not provide timeout.
+                When REST-AT transaction is bridged to JTA then the bridged JTA transaction
+                is created with the default timeout defined by the container.
+            </para>
         </section>
         <section id="_outbound_bridge">
             <title>Outbound Bridge</title>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11849

this is part of the fix presented at the https://github.com/jbosstm/narayana/pull/1425

Adding information about timeout of the bridged JTA transactions for XTS and RTS.