### PR TITLE
JBTM-2929 LRA guide

### DIFF
--- a/project/en-US/lra/examples.xml
+++ b/project/en-US/lra/examples.xml
@@ -1,0 +1,91 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+<!ENTITY % BOOK_ENTITIES SYSTEM "../project_documentation.ent">
+%BOOK_ENTITIES;
+]>
+<section id="lra-examples">
+    <title>Examples</title>
+
+<section>
+    <title>LRA Quickstart Examples</title>
+    <para>
+        There are some quickstarts with README.md files for using LRAs in the quickstart repository:
+        <ulink url="https://github.com/jbosstm/quickstart/tree/master/rts/lra-examples"></ulink>
+        and
+        <ulink url="https://github.com/jbosstm/quickstart/tree/master/rts/lra"></ulink>
+    </para>
+</section>
+<section>
+    <title>Participating in Long Running Actions</title>
+    <para>
+        The following code snippet shows the basic steps for writing service methods
+	(and associated participant resource) that will result in the registration
+	of a participant in a new or an existing LRA.
+    </para>
+
+    <programlisting language="java" linenumbering="unnumbered">
+@LRA(value = LRA.Type.REQUIRED, // if there is no incoming context a new one is created
+     cancelOn = {
+         Response.Status.INTERNAL_SERVER_ERROR // cancel on a 500 code
+     },
+     cancelOnFamily = {
+         Response.Status.Family.CLIENT_ERROR // cancel on any 4xx code
+     },
+     end = false) // the LRA will continue to run when the method finishes
+@Path("/book")
+@POST
+public Response bookTrip(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId,
+                         @HeaderParam(LRA_HTTP_PARENT_CONTEXT_HEADER) URI parentLRA) {
+    if (parentLRA != null) { // is the context nested
+          // code which is sensitive to executing with a nested context goes here
+    }
+    ...
+}
+
+@LRA(LRA.Type.MANDATORY, // requires an active context before method can be executed
+     end = true) // end the LRA started by the bookTrip method
+@Path("/confirm")
+@PUT
+public Booking confirmTrip(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId,
+                           @HeaderParam(LRA_HTTP_PARENT_CONTEXT_HEADER) URI parentLRA,
+                           Booking booking) throws BookingException {
+    if (parentLRA != null) { // is the context nested
+          // code which is sensitive to executing with a nested context goes here
+    }
+    // lookup data associated with the incoming LRA (lraId)
+    ...
+}
+
+@Complete
+@Path("/complete")
+@PUT
+public Response completeWork(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId)
+{
+    /*
+     * Free up resources allocated in the context of the LRA identified by the
+     * value in the injected JAX-RS header.
+     *
+     * Since there is no @Status method in this class, completeWork MUST be
+     * idempotent and MUST return the status.
+     */
+    return Response.ok(ParticipantStatus.Completed.name()).build();
+}
+
+@Compensate
+@Path("/compensate")
+@PUT
+public Response compensateWork(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId)
+{
+    /*
+     * The LRA identified by the value in the injected JAX-RS header was
+     * cancelled so the business logic should compensate for any actions
+     * that have been performed while running in its context.
+     *
+     * Since there is no @Status method in this class, compensateWork MUST be
+     * idempotent and MUST return the status
+    */
+    return Response.ok(ParticipantStatus.Compensated.name()).build();
+}
+    </programlisting>
+</section>
+</section>

--- a/project/en-US/lra/integration.xml
+++ b/project/en-US/lra/integration.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+<!ENTITY % BOOK_ENTITIES SYSTEM "../project_documentation.ent">
+%BOOK_ENTITIES;
+]>
+<section id="lra-integration">
+    <title>Runtime Integration</title>
+
+    <para>
+    To date we have only integrated with thorntail or standalone. The near term plan is
+    to provide a quarkus extension and a WildFly subsystem for running coordinators and
+    participants.
+    </para>
+</section>

--- a/project/en-US/lra/jaxrs.xml
+++ b/project/en-US/lra/jaxrs.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+<!ENTITY % BOOK_ENTITIES SYSTEM "../project_documentation.ent">
+%BOOK_ENTITIES;
+]>
+<section>
+    <title>JAX-RS services</title>
+
+    <para>
+    Primary support is for JAX-RS based services to participate in transactional
+    Long Running Actions (LRAs). Full details are available in the MP-LRA
+    specification document
+    <ulink url="https://github.com/eclipse/microprofile-lra/blob/master/spec/src/main/asciidoc/microprofile-lra-spec.adoc"></ulink>.
+    Also look in the examples section <xref linkend="lra-examples" /> below and in the MP-LRA TCK.
+    </para>
+</section>

--- a/project/en-US/lra/lra.xml
+++ b/project/en-US/lra/lra.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+<!ENTITY % BOOK_ENTITIES SYSTEM "../project_documentation.ent">
+%BOOK_ENTITIES;
+]>
+<chapter>
+    <title>Long Running Actions (LRA)</title>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="overview.xml" />
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="jaxrs.xml" />
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="non-jaxrs.xml" />
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="examples.xml" />
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="integration.xml" />
+</chapter>

--- a/project/en-US/lra/non-jaxrs.xml
+++ b/project/en-US/lra/non-jaxrs.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+<!ENTITY % BOOK_ENTITIES SYSTEM "../project_documentation.ent">
+%BOOK_ENTITIES;
+]>
+<section>
+    <title>Non JAX-RS services</title>
+
+    <para>
+    We also support POJO style participants, details of which are available in the
+    specification and TCK available on the MP-LRA github repository
+    <ulink url="https://github.com/eclipse/microprofile-lra"></ulink>
+    </para>
+</section>

--- a/project/en-US/lra/overview.xml
+++ b/project/en-US/lra/overview.xml
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+<!ENTITY % BOOK_ENTITIES SYSTEM "../project_documentation.ent">
+%BOOK_ENTITIES;
+]>
+<section>
+    <title>Overview</title>
+
+    <para>
+    This guide describes the Naryana implementation, or Naryana LRA for short, of the MicroProfile LRA specification
+    <ulink url="https://github.com/eclipse/microprofile-lra/blob/master/spec/src/main/asciidoc/microprofile-lra-spec.adoc"></ulink>
+    The specification introduces annotations and APIs for services to coordinate long running activities
+    whilst still maintaining loose coupling and doing so in such a way as to guarantee a globally
+    consistent outcome without the need to take locks on data for extended periods. The specification
+    has similarities to WS-BA except that it uses a simplified compensation model and as such it
+    can expose certain failure conditions that are not present in WS-BA. Please refer to 
+    <ulink url="https://github.com/eclipse/microprofile-lra/blob/master/spec/src/main/asciidoc/microprofile-lra-spec.adoc#the-model"></ulink> for details of the state model used by the LRA specification.
+    </para>
+
+    <para>
+    The basic idea is to group a collection of compensatable JAX-RS service interactions within
+    a context, called a Long Running Action (LRA). The context is propagated on JAX-RS service
+    requests and responses using a JAX-RS header. The implementation automatically
+    adds the header to requests and responses before and after service method invocation
+    (using JAX-RS filters as an implementation technique). An attribute of the @LRA annotation
+    determines how the LRA is started and/or ended.
+    </para>
+
+    <para>
+    A service may join the context by, in the case of a JAX-RS resource, providing REST
+    endpoints (via annotations) that the implementation should invoke when the LRA is
+    later closed or cancelled. The specification is transactional in the sense that all the
+    endpoints involved in the interaction are informed about the decision to close or
+    cancel the context regardless of system failures.
+    </para>
+</section>

--- a/project/en-US/project_documentation.xml
+++ b/project/en-US/project_documentation.xml
@@ -10,6 +10,7 @@
     <xi:include href="jta/jta.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
     <xi:include href="jts/jts.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
     <xi:include href="xts/xts.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
+    <xi:include href="lra/lra.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
     <xi:include href="rts/rts.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
     <xi:include href="stm/stm.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
     <xi:include href="blacktie/blacktie.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-2929

This PR adds minimal documentation to the guide for using LRA.
I have kept the text short, relying on the specification, TCK and the documentation that we will provide in the various runtime integrations (quarkus and WildFly and both planned) for in depth information.

To see how the doc renders you would need to check out the PR and type ./build.sh install and the resulting HTML file may be viewed in a browser, for example:

file:///home/mmusgrov/src/forks/narayana/documentation/project/target/docbook/publish/en-US/html_single/index.html#d0e15502