### PR TITLE
Fix version and typo

### DIFF
--- a/product/en-US/product_documentation.ent
+++ b/product/en-US/product_documentation.ent
@@ -1,6 +1,6 @@
 <!ENTITY PRODUCT "Narayana">
 <!ENTITY BOOKID "Narayana_Documentation">
-<!ENTITY VERSION "7.0.3.Final-SNAPSHOT-SNAPSHOT">
+<!ENTITY VERSION "7.0.3.Final-SNAPSHOT">
 <!ENTITY YEAR "2014">
 <!ENTITY HOLDER "JBoss.org">
 <!ENTITY APPSERVER "WildFly Application Server">

--- a/project/en-US/lra/overview.xml
+++ b/project/en-US/lra/overview.xml
@@ -7,7 +7,7 @@
     <title>Overview</title>
 
     <para>
-    This guide describes the Naryana implementation, or Naryana LRA for short, of the MicroProfile LRA specification
+    This guide describes the Narayana implementation, or Narayana LRA for short, of the MicroProfile LRA specification
     <ulink url="https://github.com/eclipse/microprofile-lra/blob/master/spec/src/main/asciidoc/microprofile-lra-spec.adoc"></ulink>
     The specification introduces annotations and APIs for services to coordinate long running activities
     whilst still maintaining loose coupling and doing so in such a way as to guarantee a globally

--- a/project/en-US/project_documentation.ent
+++ b/project/en-US/project_documentation.ent
@@ -1,6 +1,6 @@
 <!ENTITY PRODUCT "Narayana">
 <!ENTITY BOOKID "Narayana_Documentation">
-<!ENTITY VERSION "7.0.3.Final-SNAPSHOT-SNAPSHOT">
+<!ENTITY VERSION "7.0.3.Final-SNAPSHOT">
 <!ENTITY YEAR "2014">
 <!ENTITY HOLDER "JBoss.org">
 <!ENTITY APPSERVER "WildFly Application Server">


### PR DESCRIPTION
The ent file had a wrong version which was generating wrong links during the build. i.e. https://www.narayana.io//docs/product/index.html#ref-WSATMultiService