### PR TITLE
JBTM-3987 round-robin, sticky and random load balancer configuration

### DIFF
--- a/src/main/asciidoc/project/lra/jaxrs.adoc
+++ b/src/main/asciidoc/project/lra/jaxrs.adoc
@@ -5,8 +5,12 @@ Primary support is for JAX-RS based services to participate in transactional Lon
 Full details are available in the MP-LRA specification document https://github.com/eclipse/microprofile-lra/blob/master/spec/src/main/asciidoc/microprofile-lra-spec.adoc.
 Also look in the xref:examples.adoc#lra_examples[examples section] below and in the MP-LRA TCK.
 
-== Configuring the location of the coordinator when starting new Long Running Actions
+== Configuring the location of the Coordinator and Load Balancer when starting new Long Running Actions
 
-Services should be configured with a comma separated list of URLs of coordinators using a property called `lra.coordinator.urls`, and if unset then `http://localhost:8080/lra-coordinator` will be used. When a service starts a new LRA one of the URLs will be chosen in a "round robin" fashion. Note that the chosen coordinator must be available for the lifetime of the LRA (or restarted on the same endpoint, with access to the same object store, if it fails). The https://smallrye.io/smallrye-stork/latest[Smallry Stork service discovery and client-side load-balancing framework] is used to support a static list of coordinators.
+Services should be configured with a comma separated list of URLs of coordinators using a property called `lra.coordinator.urls`, and if unset then `http://localhost:8080/lra-coordinator` will be used. When a service starts a new LRA one of the URLs will be chosen according to the configured load balancing strategy, the default is to choose one in a "round robin" fashion. Note that the chosen coordinator must be available for the lifetime of the LRA (or restarted on the same endpoint, with access to the same object store, if it fails). The https://smallrye.io/smallrye-stork/latest[Smallry Stork service discovery and client-side load-balancing framework] is used to support a static list of coordinators and load balancing strategies.
 
-Stork supports a number of different load balancing algorithms and service discovery backends. Currently only the Round Robin load balancing algorithm and Static List discovery backend are supported.
+The load balancing algorithm is controlled by the value of a property called `lra.coordinator.lb-method`. The property supports the following values (refer to the Stork documentation for more detail about the various algorithms):
+
+* `round-robin`: Iterates over the set of coordinators.
+* `sticky`: Selects a single coordinator and keeps using it until it fails. Then, it selects another one.
+* `random`: Picks a random coordinator every time.


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3987

How to configure client side coordinator load balancing strategy to use when a service starts an LRA. Choices include use of round-robin, sticky and random strategies. The least-requests, least-response-time and power-of-two-choices strategies will be added in a future update since it requires some further changes to narayana lra.

The documentation is for the feature added in [lra pr/53](https://github.com/jbosstm/lra/pull/53): ie Depends on  jbosstm/lra#53